### PR TITLE
Orthogonality Graph method from Nutini et al. (#46)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,28 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 19.10b0
+  rev: 20.8b1
   hooks:
     - id: black
       language_version: python3.8
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.9
+  rev: 3.8.4
   hooks:
     - id: flake8
       language_version: python3.8
 
 - repo: https://github.com/asottile/seed-isort-config
-  rev: v2.1.1
+  rev: v2.2.0
   hooks:
     - id: seed-isort-config
 
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+  rev: v5.6.4
   hooks:
   - id: isort
 
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
+  rev: v3.3.0
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files

--- a/src/kaczmarz/__init__.py
+++ b/src/kaczmarz/__init__.py
@@ -12,7 +12,7 @@ __copyright__ = "Copyright (c) 2020, Jacob Moorman"
 
 
 from ._abc import Base
-from ._variants import (
+from ._variants import (  # OrthogonalMaxDistance,
     Cyclic,
     MaxDistance,
     Quantile,

--- a/src/kaczmarz/_abc.py
+++ b/src/kaczmarz/_abc.py
@@ -37,7 +37,13 @@ class Base(ABC):
     """
 
     def __init__(
-        self, A, b, x0=None, tol=1e-5, maxiter=None, callback=None,
+        self,
+        A,
+        b,
+        x0=None,
+        tol=1e-5,
+        maxiter=None,
+        callback=None,
     ):
         self._A, self._b, self._row_norms = normalize_system(A, b)
         self._n_rows = len(self._b)

--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -210,23 +210,22 @@ class RandomOrthoGraph(kaczmarz.Base):
 
     def __init__(self, *args, p=None, **kwargs):
         super().__init__(*args, **kwargs)
-        self._ortho_graph = self._A @ self._A.T
+        self._gramian = self._A @ self._A.T
 
-        self._i_to_newly_selectable = {
-            i: self._newly_selectable(i) for i in range(self._n_rows)
+        # Map each row index i to indexes of rows that are NOT orthogonal to it.
+        self._i_to_neighbors = {
+            i: np.argwhere(self._gramian[i, :]).flatten() for i in range(self._n_rows)
         }
 
+        # Initially, any row whose equation is not satisfied is selectable.
         self._selectable = np.argwhere(self._A @ self._x0 - self._b).flatten()
         if p is None:
             p = np.ones((self._n_rows,))
         self._p = p
 
-    def _newly_selectable(self, i):
-        return np.argwhere(self._ortho_graph[i, :])
-
     def _update_selectable(self, ik):
         # Every time a row is selected, all of its neighbors become selectable, and itself becomes unselectable.
-        newly_selectable = self._i_to_newly_selectable[ik]
+        newly_selectable = self._i_to_neighbors[ik]
         selectable_with_ik = np.union1d(self._selectable, newly_selectable)
         self._selectable = np.setdiff1d(selectable_with_ik, [ik], assume_unique=True)
 
@@ -236,3 +235,8 @@ class RandomOrthoGraph(kaczmarz.Base):
         ik = np.random.choice(self._selectable, p=p)
         self._update_selectable(ik)
         return ik
+
+    @property
+    def selectable(self):
+        """(s,) array: Selectable row indexes at the current iteration."""
+        return self._selectable.copy()

--- a/tests/test_ortho_graph.py
+++ b/tests/test_ortho_graph.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+
+import kaczmarz
+
+
+def test_selectable_set(eye33, ones3):
+
+    x0 = np.zeros(3)
+    solver = kaczmarz.RandomOrthoGraph(eye33, ones3, x0)
+
+    # Length is 3 for two iterations because first iteration yields x0 without performing an update.
+    assert 3 == len(solver.selectable)
+    next(solver)
+    assert 3 == len(solver.selectable)
+    next(solver)
+    assert 2 == len(solver.selectable)
+    next(solver)
+    assert 1 == len(solver.selectable)
+    next(solver)
+    assert 0 == len(solver.selectable)
+
+    with pytest.raises(StopIteration):
+        next(solver)

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ commands =
     python -m pytest --basetemp={envtmpdir} \
                      --cov-report=term-missing \
                      --cov=kaczmarz \
+                     -xs \
                      tests/
 
 


### PR DESCRIPTION
* Added Nutini Orthogonality graph method and test

* Added true orthogonality method

* updated orthogonality method

* Added Orthogonal Max-Distance

* Fix bug and refactor docstring.

* Even better docstrings.

* Updated orthogonal max-distance

* merge conflict fixed in orthogonal max distance

* Update _variants.py

added access to selectable rows in the nutini algorithm.

* added preliminary tests with bugs for orthogonality method

* Fix test bug for orthogonality graph method.

* Remove print, change next(iterator) to next(solver)

* Added true orthogonality method

* updated orthogonality method

* Added Orthogonal Max-Distance

* Fix bug and refactor docstring.

* Even better docstrings.

* Updated orthogonal max-distance

* Update _variants.py

added access to selectable rows in the nutini algorithm.

* added preliminary tests with bugs for orthogonality method

* Fix test bug for orthogonality graph method.

* Remove print, change next(iterator) to next(solver)

* Update linters.

Co-authored-by: yotamyaniv <yotamya@ucla.edu>
Co-authored-by: yotamyaniv <62568573+yotamyaniv@users.noreply.github.com>

**Pull request recommendations:**
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
