### PR TITLE
Ordered cyclic (#47)

### DIFF
--- a/src/kaczmarz/_variants.py
+++ b/src/kaczmarz/_variants.py
@@ -23,13 +23,16 @@ class Cyclic(kaczmarz.Base):
        Série A, Sciences Mathématiques*, 35, 335–357, 1937
     """
 
-    def __init__(self, *base_args, **base_kwargs):
+    def __init__(self, *base_args, order=None, **base_kwargs):
         super().__init__(*base_args, **base_kwargs)
         self._row_index = -1
+        if order is None:
+            order = range(self._n_rows)
+        self._order = order
 
     def _select_row_index(self, xk):
         self._row_index = (1 + self._row_index) % self._n_rows
-        return self._row_index
+        return self._order[self._row_index]
 
 
 class MaxDistanceLookahead(kaczmarz.Base):

--- a/tests/test_cyclic.py
+++ b/tests/test_cyclic.py
@@ -20,3 +20,21 @@ def test_row_indexes(eye23, ones2):
     assert [1, 1, 0] == list(next(iterator))
     with pytest.raises(StopIteration):
         next(iterator)
+
+
+def test_ordered_cyclic(eye23, ones2):
+    x = np.zeros(3)
+    cyclic = kaczmarz.Cyclic(eye23, ones2, order=[1, 0])
+    assert 1 == cyclic._select_row_index(x)
+    assert 0 == cyclic._select_row_index(x)
+    assert 1 == cyclic._select_row_index(x)
+    assert 0 == cyclic._select_row_index(x)
+
+    x0 = np.zeros(3)
+    iterates = kaczmarz.Cyclic.iterates(eye23, ones2, x0, order=[1, 0])
+    iterator = iter(iterates)
+    assert [0, 0, 0] == list(next(iterator))
+    assert [0, 1, 0] == list(next(iterator))
+    assert [1, 1, 0] == list(next(iterator))
+    with pytest.raises(StopIteration):
+        next(iterator)


### PR DESCRIPTION
* added optional order for the Cyclic variant

* use xk instead of self._xk when available

* undo changes

* change order to be default argument

* tests for cyclic with order

* linting

**Pull request recommendations:**
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
